### PR TITLE
Support .NET 10

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
     
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>


### PR DESCRIPTION
This pull request makes a minor update to the project's build configuration by adding support for a new .NET target framework.

- Added `net10.0` to the `TargetFrameworks` property in `src/Directory.Build.props`, enabling builds for the upcoming .NET 10.0 release.